### PR TITLE
Alert and Badge widget tests. 

### DIFF
--- a/src/components/widgets/Alert.jsx
+++ b/src/components/widgets/Alert.jsx
@@ -14,7 +14,7 @@ const icons = {
 const icon = (name) => <Icon name={icons[name]} size="medium" theme="none" />;
 
 const Alert = ({ title, message, type }) => (
-  <div className={"alert alert-" + type} role="alert">
+  <div className={"alert alert-" + type} role="alert" data-testid="alert-test">
     <h3 className="alert-title">
       {title && icon(type)}
       <strong>{title}</strong>

--- a/src/components/widgets/Alert.test.js
+++ b/src/components/widgets/Alert.test.js
@@ -1,0 +1,40 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { getAllByTitle, getByTitle, getByText, render, screen, TestRenderer } from "@testing-library/react";
+import Alert from "./Alert";
+import renderer from 'react-test-renderer';
+import { Fragment } from "react";
+import { isExportDeclaration } from "typescript";
+
+describe('alert widget tests', () => {
+  it('component renders correctly', () =>{;
+    const tree = renderer.create(<Alert title="Alert" message = "hello" type="danger"/>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  it("alert has title and message", () => {
+     render(<Alert title ="Hello!" message="you have alert" type="danger" />);
+     const alert = screen.getByTestId("alert-test");
+     expect(alert).toHaveTextContent("Hello!");
+     expect(alert).toHaveTextContent("you have alert");
+   });
+   it("alert has null title and message", () => {
+    render(<Alert title ="" message="you have alert" type="danger" />);
+    const alert = screen.getByTestId("alert-test");
+    expect(alert).toHaveTextContent("you have alert");
+  });
+  it("test type: info", () => {
+    render(<Alert title ="" message="info alert" type="info" />);
+    const alert = screen.getByTestId("alert-test");
+    expect(alert).toHaveTextContent("info alert");
+  });
+  it("test type: success", () => {
+    render(<Alert title ="" message="success alert" type="success" />);
+    const alert = screen.getByTestId("alert-test");
+    expect(alert).toHaveTextContent("success alert");
+  });
+  it("test type: warning", () => {
+    render(<Alert title ="" message="warning alert" type="warning" />);
+    const alert = screen.getByTestId("alert-test");
+    expect(alert).toHaveTextContent("warning alert");
+  });
+})
+

--- a/src/components/widgets/Badge.jsx
+++ b/src/components/widgets/Badge.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import "./Badge.scss";
 
 const Badge = ({ text }) => (
-  <div className="evo-badge">
+  <div className="evo-badge" role="badge" data-testid="badge-test">
     <span>{text}</span>
   </div>
 );

--- a/src/components/widgets/Badge.test.js
+++ b/src/components/widgets/Badge.test.js
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import Badge from "./Badge";
+import renderer from 'react-test-renderer';
+
+describe('Badge widget tests', () => {
+    it('component renders correctly', () =>{
+    const tree = renderer.create(<Badge text="Your Badge"/>).toJSON();
+    expect(tree).toMatchSnapshot();
+    });
+    it('badge shows text string correctly',()=>{
+    render(<Badge text="You got a badge!" />);
+    const badge = screen.getByTestId("badge-test");
+    expect(badge).toHaveTextContent("You got a badge!");
+    });  
+    it('badge shows number correctly',()=>{
+    render(<Badge text={4152341234} />);
+    const badge = screen.getByTestId("badge-test");
+    expect(badge).toHaveTextContent(4152341234);
+    }); 
+    it('badge shows double byte text correctly',()=>{
+    render(<Badge text="美味しい" />);
+    const badge = screen.getByTestId("badge-test");
+    expect(badge).toHaveTextContent("美味しい");
+    });  
+    it('badge shows special character text correctly',()=>{
+    render(<Badge text="Ça va? #@$%" />);
+    const badge = screen.getByTestId("badge-test");
+    expect(badge).toHaveTextContent("Ça va? #@$%");
+    }); 
+}) 

--- a/src/components/widgets/__snapshots__/Alert.test.js.snap
+++ b/src/components/widgets/__snapshots__/Alert.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`alert widget tests component renders correctly 1`] = `
+<div
+  className="alert alert-danger"
+  data-testid="alert-test"
+  role="alert"
+>
+  <h3
+    className="alert-title"
+  >
+    <svg
+      aria-hidden="true"
+      className={null}
+      focusable="false"
+      onClick={null}
+      role="presentation"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M2.2,16.06L3.88,12L2.2,7.94L6.26,6.26L7.94,2.2L12,3.88L16.06,2.2L17.74,6.26L21.8,7.94L20.12,12L21.8,16.06L17.74,17.74L16.06,21.8L12,20.12L7.94,21.8L6.26,17.74L2.2,16.06M13,17V15H11V17H13M13,13V7H11V13H13Z"
+      />
+    </svg>
+    <strong>
+      Alert
+    </strong>
+  </h3>
+  <p>
+    hello
+  </p>
+</div>
+`;

--- a/src/components/widgets/__snapshots__/Badge.test.js.snap
+++ b/src/components/widgets/__snapshots__/Badge.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Badge widget tests component renders correctly 1`] = `
+<div
+  className="evo-badge"
+  data-testid="badge-test"
+  role="badge"
+>
+  <span>
+    Your Badge
+  </span>
+</div>
+`;


### PR DESCRIPTION
…Added role and data-testid to the corresponding .jsx. Added snapshots files.
One question. The Alert component rendered, when type is specified, has the SVG tag below (see the snapshot file in the commit). Is this expected? 

 <svg
      aria-hidden="true"
      className={null}
      focusable="false"
      onClick={null}
      role="presentation"
      viewBox="0 0 24 24"
    >
      <path
        d="M2.2,16.06L3.88,12L2.2,7.94L6.26,6.26L7.94,2.2L12,3.88L16.06,2.2L17.74,6.26L21.8,7.94L20.12,12L21.8,16.06L17.74,17.74L16.06,21.8L12,20.12L7.94,21.8L6.26,17.74L2.2,16.06M13,17V15H11V17H13M13,13V7H11V13H13Z"
      />
    </svg>
